### PR TITLE
QR Code scan on gallery index page

### DIFF
--- a/pages/galleries/galleries.js
+++ b/pages/galleries/galleries.js
@@ -81,5 +81,12 @@ Page({
     wx.navigateTo({
       url: `/pages/show_gallery/show_gallery?id=${galleryId}`,
     });
+  },
+  callQRcode: function () {
+    wx.scanCode({
+      success: (res) => {
+        console.log(res)
+      }
+    });
   }
 })


### PR DESCRIPTION
Able to open QR scanner, but still need to know how to link gallery's QR code to
be able to add the gallery to our index page.. Also need to discuss if we want
to allow users to add the code from their albumn. Currently the functionality
allows this.